### PR TITLE
Removes references for non-existent sections.

### DIFF
--- a/environment.tex
+++ b/environment.tex
@@ -339,7 +339,8 @@ tuple.
 Finally, notice that the above discussion of SFW queries did not capture the set
 operators \gl{UNION}, \gl{INTERSECT} and \gl{EXCEPT}. As is the case with SQL
 semantics too, the coordination of \gl{ORDER BY} with the set operators requires
-attention, as discussed in Section~\ref{sec:order-with-set}.
+attention. \eat{FIXME, as discussed in Section~\ref{section:order-by}
+\ref{sec:order-with-set}.}
 
 \paragraph{PartiQL clauses as operators} 
 In summary, each clause of PartiQL is an operator that inputs/outputs binding

--- a/orderby.tex
+++ b/orderby.tex
@@ -25,7 +25,7 @@ output. In this case, the \gl{AT} structure in the \gl{FROM} clause (recall,
 Section~\ref{sec:single-item-from}) can capture the input order and the
 \gl{ORDER BY} can recreate it. However, this order preservation mechanism is
 tedious for the user. Thus, \gl{ORDER BY} also offers an order preservation
-directive (Section~\ref{sec:order-preservation}).
+directive. \eat{FIXME (Section~\ref{sec:order-preservation}).}
 %
 \end{enumerate}
 

--- a/subqueryCoercion.tex
+++ b/subqueryCoercion.tex
@@ -26,8 +26,8 @@ lhs of a comparison operator where the lhs is an array literal, it coerces into
 array, per Section~\ref{sec:select-coercion-array}.)
 \item if it is an SFW subquery expression that (a) is not the collection
 expression of a \gl{FROM} clause item and (b) is not the rhs of an \gl{IN}. (If
-it is the rhs of an \gl{IN} then it should not be coerced; see note on semantics
-of \gl{IN}, Section~\ref{sec:in}.)
+it is the rhs of an \gl{IN} then it should not be coerced.)
+\eat{FIXME ; see note on semantics of \gl{IN}, Section~\ref{sec:in}.)}
 \end{itemize}
 
 Essentially, a subquery that is coerced may appear in all clauses except the


### PR DESCRIPTION
We have some sections that are still being finalized this removes
them for now using `eat{}`.

Resolves #5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
