### PR TITLE
Associativity of JOIN

### DIFF
--- a/from.tex
+++ b/from.tex
@@ -300,10 +300,10 @@ may write (as is common in SQL):
 \begin{lstlisting}
 (*$f_1$*), (*$f_2$*), (*$f_3$*) (*$\eqv$*)
 (*$f_1$*) CROSS JOIN (*$f_2$*) CROSS JOIN (*$f_3$*) (*$\eqv$*)
-(*$f_1$*) LEFT JOIN (*$f_2$*) ON TRUE CROSS JOIN (*$f_3$*) ON TRUE (*$\eqv$*)
+(*$f_1$*) JOIN (*$f_2$*) ON TRUE JOIN (*$f_3$*) ON TRUE (*$\eqv$*)
 ((*$f_1$*), (*$f_2$*)), (*$f_3$*) (*$\eqv$*)
 ((*$f_1$*) CROSS JOIN (*$f_2$*)) CROSS JOIN (*$f_3$*) (*$\eqv$*)
-((*$f_1$*) LEFT JOIN (*$f_2$*) ON TRUE) CROSS JOIN (*$f_3$*) ON TRUE (*$\eqv$*)
+((*$f_1$*) JOIN (*$f_2$*) ON TRUE) JOIN (*$f_3$*) ON TRUE (*$\eqv$*)
 \end{lstlisting}
 
 \paragraph{Semantics} Consider the following:


### PR DESCRIPTION


*Description of changes:*

I believe that the section on associativity of JOIN contains an error in the equivalences presented between `,` `JOIN` and `CROSS JOIN`. This PR proposes a fix.  

See the attached pdf for the visual diff
[join-associativity-fix.pdf](https://github.com/partiql/partiql-spec/files/4464018/join-associativity-fix.pdf)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
