### PR TITLE
Directs intermediate and final pdf output of latexmk to build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 *.fls
 *.toc
 *.fdb_latexmk
+build
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To build a PDF, `cd` to `spec` and then:
 $ make
 ```
 
-The PDF will be placed in `spec/main.pdf`.
+The PDF will be placed in `spec/build/main.pdf`.
 
 To clean up the various build files including the PDF:
 

--- a/psr/PSR-TEMPLATE.md
+++ b/psr/PSR-TEMPLATE.md
@@ -1,0 +1,99 @@
+# Instructions
+
+- Copy this file to `proposals/<unique-feature-name>.md`.
+- Fill in the sections below.
+- Delete this section.
+- Submit a pull request your PSR.
+
+# PartiQL Specification Request
+
+- Feature Name: (fill me in with a unique name, i.e. `my-awesome-feature`)
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- PartiQL Implementation Issue(s): 
+    - (fill me in with any known links to issues for the implemention of this PSR)
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Explain the proposal as if it was already included in the language and you were teaching it to a PartiQL end-user. 
+That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how PartiQL query authors and service owners should *think* about the feature, and how it should impact 
+the way they use PartiQL. It should explain the impact as concretely as possible.
+- If applicable, provide sample queries that utilize the new feature, including source data and expected results.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the PSR. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- It is clear that it does not break compliance with the SQL_-92 specification, or if it does, articulate why it is 
+necessary to do so.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed 
+proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?  What possible downsides does this proposal have?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- What is the impact of not doing this?
+- What other designs have been considered and what is the rationale for not choosing them?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal. A few examples of what this can include 
+are:
+
+- Is this part of the SQL-92 specification or an extension of it?
+- Does this feature exist in other SQL impelementations?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to 
+refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other SQL implementations, 
+provide readers of your PSR with a fuller picture.  If there is no prior art, that is fine - your ideas are 
+interesting to us whether they are brand new or if it is an adaptation from other languages.
+
+Note that while precedent set by other SQL implementations is some motivation, it does not on its own motivate a PSR.
+Please also take into consideration that PartiQL sometimes intentionally diverges from common language features.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the PSR process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this PSR that could be addressed in the future independently 
+of the solution that comes out of this PSR?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Think about what the natural extension and evolution of your proposal would be and how it would affect the language 
+and project as a whole in a holistic way. Try to use this section as a tool to more fully consider all possible 
+interactions with the project and language in your proposal.  Also consider how this all fits into the roadmap for 
+the project and of the relevant sub-team.  
+
+This is also a good place to "dump ideas", if they are out of scope for the PSR you are writing but otherwise related.
+
+If you have tried and cannot think of any future possibilities, you may simply state that you cannot think of anything.
+

--- a/psr/README-PSR.md
+++ b/psr/README-PSR.md
@@ -73,13 +73,10 @@ PSRs may be submitted by any party.
    the PSR and repeat steps 2-8.
 9. Create a GitHub pull request to revise the formal specification with the
    changes outlined in the PSR.
-
    
 ![PSR Flowchar](psr-process.jpeg)
 
 <!-- 
-
-
 
 To edit this flowchart:
 

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -1,11 +1,11 @@
 SPECPDF=main.pdf
+OUTDIR=build
 
 .PHONY: all clean $(SPECPDF)
 
 all: $(SPECPDF)
 
 $(SPECPDF): *.tex
-	latexmk	-pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make main.tex
-
+	latexmk	-pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make main.tex -outdir=$(OUTDIR)
 clean:
-	latexmk -C
+	latexmk -C -outdir=$(OUTDIR)


### PR DESCRIPTION
This helps to keep the directories containing our `.tex` files much cleaner.

This PR builds on the changes from #20, which changes the directory structure a bit.  Ideally, #20 is merged first.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
