### PR TITLE
Fix typo in PIVOT example

### DIFF
--- a/src/pivot.adoc
+++ b/src/pivot.adoc
@@ -32,7 +32,7 @@ collection of tuples.
 [source%unbreakable, partiql]
 ----
 PIVOT x.v AT x.a
-FROM << {'a': 'first', 'v': 'john'}, {'a': 'last', 'v': 'doe'} >>
+FROM << {'a': 'first', 'v': 'john'}, {'a': 'last', 'v': 'doe'} as x >>
 ----
 
 The result is

--- a/src/pivot.adoc
+++ b/src/pivot.adoc
@@ -32,7 +32,7 @@ collection of tuples.
 [source%unbreakable, partiql]
 ----
 PIVOT x.v AT x.a
-FROM << {'a': 'first', 'v': 'john'}, {'a': 'last', 'v': 'doe'} as x >>
+FROM << {'a': 'first', 'v': 'john'}, {'a': 'last', 'v': 'doe'} >> as x
 ----
 
 The result is


### PR DESCRIPTION
**Before**
```
PartiQL> PIVOT x.v AT x.a
   | FROM << {'a': 'first', 'v': 'john'}, {'a': 'last', 'v': 'doe'} >>
   | 
===' 
org.partiql.lang.eval.EvaluationException: No such binding: x.
	Evaluator Error: at line 1, column 14: Binding 'x' does not exist
```

**After**
```
PartiQL> PIVOT x.v AT x.a
   | FROM << {'a': 'first', 'v': 'john'}, {'a': 'last', 'v': 'doe'} >> as x
   | 
===' 
{
  'first': 'john',
  'last': 'doe'
}
--- 
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
